### PR TITLE
fix for raw string i18n

### DIFF
--- a/deform_mako/__init__.py
+++ b/deform_mako/__init__.py
@@ -1,8 +1,10 @@
+import os
 from mako.template import Template
 
 def mako_renderer_factory(directory, translator=None):
     def mako_renderer(tname, **kw):
-        template = Template(filename='%s%s.mako' % (directory, tname))
+        filename = os.path.join(directory, tname) + '.mako'
+        template = Template(filename=filename)
         return template.render(_=translator, **kw)
     return mako_renderer
 

--- a/deformdemo/app.py
+++ b/deformdemo/app.py
@@ -33,7 +33,9 @@ from translationstring import TranslationStringFactory
 _ = TranslationStringFactory('deform')
 css = HtmlFormatter().get_style_defs('.highlight')
 
-def translator(term):
+def translator(term, domain='deform'):
+    if not hasattr(term, 'interpolate'): # not a translation string
+        term = TranslationStringFactory(domain)(term)
     return get_localizer(get_current_request()).translate(term)
 
 mako_template_dir = resource_filename('deform_mako', 'templates/')


### PR DESCRIPTION
Fix for raw string i18n; all tests pass.

Also replace hardcoded path computation with os.path.join.
